### PR TITLE
修复 Maple Mono CN 字体名称与安装的包不匹配

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 首先，输入命令(如使用`paru`,替换'yay'即可)：
 ```
 sudo pacman -S inter-font ttf-nerd-fonts-symbols-mono 
-yay -S otf-apple-pingfang ttf-apple-emoji ttf-maplemono-nf-unhinted
+yay -S otf-apple-pingfang ttf-apple-emoji ttf-maplemono-nf-cn-unhinted
 ```
 
 最后，把文件放到`~/.config/fontconfig/`里去，重启/注销登陆后**字体配置会自动生效**。

--- a/fonts.conf
+++ b/fonts.conf
@@ -110,7 +110,7 @@
  <alias>
   <family>monospace</family>
   <prefer>
-   <family>Maple Mono CN</family>
+   <family>Maple Mono NF CN</family>
    <family>Symbols Nerd Font Mono</family>
   </prefer>
  </alias>


### PR DESCRIPTION
fc-match 'Maple Mono CN' 并没有匹配对应的字体。不知道你要不要安装有 nerd font 的 Maple Mono CN。